### PR TITLE
fixes hotpatching_enabled being set to true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   timezone                                               = var.timezone
   secure_boot_enabled                                    = var.secure_boot_enabled
   vtpm_enabled                                           = var.vtpm_enabled
-  hotpatching_enabled                                    = var.patch_mode == "AutomaticByPlatform" && var.provision_vm_agent == true && strcontains(var.windows_distribution_name, "hotpatch") ? true : false
+  hotpatching_enabled                                    = var.patch_mode == "AutomaticByPlatform" && var.provision_vm_agent == true && strcontains(local.image["sku"], "hotpatch") ? true : false
   tags                                                   = var.tags
 
   source_image_reference {


### PR DESCRIPTION
When `var.windows_distribution_name` is not set in module call and a custom image is used that does not support hotpatching this value would still be set to true. Now it will check `local.image["sku"]` instead to check for hotpatching.

<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
fixes hotpatching_enabled being set to true when custom image is supplied and there are no changes to windows_distribution_name
```
