### PR TITLE
windows: default to server 2025

### DIFF
--- a/locals_images.tf
+++ b/locals_images.tf
@@ -49,6 +49,18 @@ locals {
 
   ## Windows ##
   windows_distribution_list = {
+    windows2025az = {
+      publisher = "MicrosoftWindowsServer"
+      offer     = "WindowsServer"
+      sku       = "2025-datacenter-azure-edition"
+      version   = "latest"
+    }
+    windows2025azsmall = {
+      publisher = "MicrosoftWindowsServer"
+      offer     = "WindowsServer"
+      sku       = "2025-datacenter-azure-edition-smalldisk"
+      version   = "latest"
+    }
     windows2022azhotpatch = {
       publisher = "MicrosoftWindowsServer"
       offer     = "WindowsServer"

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "linux_distribution_name" {
 
 variable "windows_distribution_name" {
   type        = string
-  default     = "windows2022azhotpatch"
+  default     = "windows2025az"
   description = "Variable to pick an OS flavour for Windows based VM."
 }
 


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

https://learn.microsoft.com/en-us/windows-server/get-started/hotpatch#supported-platforms
Hotpatching should be supported for these SKUs
get-azvmImagesku -Location "Norway East" -PublisherName "MicrosoftWindowsServer" -Offer "windowsServer"

## Changelog entry
```
Default new windows VMs to use windows 2025 azure edition
```
