### PR TITLE
Support inputting disk_controller_type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,6 +106,7 @@ resource "azurerm_linux_virtual_machine" "linux_vm" {
   bypass_platform_safety_checks_on_user_schedule_enabled = var.bypass_platform_safety_checks_on_user_schedule_enabled
   secure_boot_enabled                                    = var.secure_boot_enabled
   vtpm_enabled                                           = var.vtpm_enabled
+  disk_controller_type                                   = var.disk_controller_type
 
   admin_ssh_key {
     username   = var.admin_username
@@ -187,6 +188,7 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   vtpm_enabled                                           = var.vtpm_enabled
   hotpatching_enabled                                    = var.hotpatching_enabled
   tags                                                   = var.tags
+  disk_controller_type                                   = var.disk_controller_type
 
   source_image_reference {
     publisher = local.image["publisher"]

--- a/variables.tf
+++ b/variables.tf
@@ -409,7 +409,7 @@ variable "disk_controller_type" {
   description = "The disk controller type for the VM. Possible values are 'SCSI' and 'NVMe'. Defaults to 'SCSI'."
   default     = null
   validation {
-    condition     = var.disk_controller_type == "SCSI" || var.disk_controller_type == "NVMe"
+    condition     = var.disk_controller_type == "SCSI" || var.disk_controller_type == "NVMe" || var.disk_controller_type == null
     error_message = "disk_controller_type must be either 'SCSI' or 'NVMe'"
   }
   

--- a/variables.tf
+++ b/variables.tf
@@ -403,3 +403,14 @@ variable "vtpm_enabled" {
   description = "Enable or disable Virtual Trusted Platform Module (vTPM) for the VM."
   default     = true
 }
+
+variable "disk_controller_type" {
+  type        = string
+  description = "The disk controller type for the VM. Possible values are 'SCSI' and 'NVMe'. Defaults to 'SCSI'."
+  default     = null
+  validation {
+    condition     = var.disk_controller_type == "SCSI" || var.disk_controller_type == "NVMe"
+    error_message = "disk_controller_type must be either 'SCSI' or 'NVMe'"
+  }
+  
+}


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->
Required to be set to "nvme" when creating _v6 sku VMs.
## Changelog entry
```
- **Support v6 image skus**
```
