### PR TITLE
Do not power on for changes only needed for initial setup

### DIFF
--- a/extensions.tf
+++ b/extensions.tf
@@ -9,9 +9,7 @@ locals {
     enable_aad_login          = var.enable_aad_login
     vm_extension              = var.vm_extension
     enable_disk_encryption    = var.enable_disk_encryption
-    type_handler_version      = var.type_handler_version
     custom_script_extension   = var.custom_script_extension
-    avd_register_session_host = var.avd_register_session_host
   })
 }
 


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
The session registrations token is only used on first registration, not for every time it is rotated. Avoid turning on the VMs just because the token has been rotated.

https://learn.microsoft.com/en-us/azure/virtual-desktop/add-session-hosts-host-pool?tabs=portal%2Cgui&pivots=host-pool-standard#generate-a-registration-key
```
